### PR TITLE
added price change event

### DIFF
--- a/gdax-pulse.js
+++ b/gdax-pulse.js
@@ -6,7 +6,7 @@ class Pulse {
         this.lastDay = now.getDate();
         this.lasUtcDay = now.getUTCDate();
         this.currentData = {
-            time: toTheMinute(now).getTime(),
+            time: toTheMinute(now),
             price: 0
         }
     }
@@ -14,7 +14,11 @@ class Pulse {
     analyze(message) {
         //update Time
         if (message.type === 'match') {
-            this.currentData.price = parseFloat(message.price);
+            let priceOfMatch = parseFloat(message.price);
+            if (priceOfMatch !== this.currentData.price) {
+                this.currentData.price = priceOfMatch;
+                this.onNewPrice(this.currentData.price, this.currentData.time);
+            }
         }
 
         if (message.time) {
@@ -67,6 +71,8 @@ class Pulse {
             this.onDay = func;
         } else if (type === 'd-utc') {
             this.onUtcDay = func;
+        } else if (type === 'new-price') {
+            this.onNewPrice = func;
         }
     }
 
@@ -77,6 +83,7 @@ class Pulse {
     onHour6() {}
     onDay() {}
     onUtcDay() {}
+    onNewPrice() {}
 }
 
 module.exports = Pulse;

--- a/test/PulseTests.js
+++ b/test/PulseTests.js
@@ -26,6 +26,25 @@ describe("#Gdax-Pulse", () => {
         });
     });
 
+    describe("#Price Events", () => {
+        let sim = new GdaxSim();
+        let pulse = new GdaxPulse();
+        sim.websocketClient.on('message', (message) => {
+            pulse.analyze(message);
+        });
+        it('Fires every time a new price is traded', () => {
+            let lastPrice = 0;
+            let ran = false;
+            pulse.on('new-price', (price) => {
+                assert(lastPrice !== price, "event run on redundent price");
+                lastPrice = price;
+                ran = true;
+            });
+            sim.backtest(TwoDays);
+            assert(ran, '"new-price" event not run');
+        });
+    });
+
     describe("#Time Events", () => {
         let sim = new GdaxSim();
         let pulse = new GdaxPulse();
@@ -92,6 +111,9 @@ describe("#Gdax-Pulse", () => {
                 test(price, time);
             });
             pulse.on('d-utc', (price, time) => {
+                test(price, time);
+            });
+            pulse.on('new-price', (price, time) => {
                 test(price, time);
             });
             sim.websocketClient.on('message', (message) => {


### PR DESCRIPTION
# Update
 - Added unit tests for feature
 - Removed call to .getTime() when pulse.currentData.time is initially made
 - Added 'new-price' to event lists